### PR TITLE
check button doesn't exist on page before appending

### DIFF
--- a/content.js
+++ b/content.js
@@ -68,11 +68,13 @@ function addButtonElement() {
     allDivs[0].firstChild.childNodes[3].childNodes[1].childNodes[1]
       .childNodes[1].firstChild.firstChild.firstChild;
 
-  buttonContainerNode.appendChild(newButton);
-
-  const targetNode =
-    allDivs[0].firstChild.childNodes[3].childNodes[1].childNodes[1]
-      .childNodes[1].childNodes[1];
+  // add extension button to page if not already there
+  if (
+    buttonContainerNode.childNodes &&
+    buttonContainerNode.lastChild.tagName !== "BUTTON"
+  ) {
+    buttonContainerNode.appendChild(newButton);
+  }
 
   // create the debunking modal
   const debunkModal = document.createElement("div");


### PR DESCRIPTION
While listening to my youtube playlist I discovered that switching to the next song must trigger the tab to update somehow. I noticed the button was being appended each time the page was sitting still when the next song came on. 

![Image 2021-04-28 at 6 38 45 PM](https://user-images.githubusercontent.com/16695037/116485595-392d0080-a851-11eb-898e-be74be0d2e07.jpg)

this added logic checks if the button is there before appending a new one to the page.

-also cleans up an old const I missed last PR (it is no longer needed now that the modal is getting appended to the body)